### PR TITLE
Add CORS configuration to API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,19 @@ jobs:
           root: ~/repo
           <<: *whitelist
 
+  deploy_rc:
+    <<: *defaults
+
+    steps:
+      - attach_workspace:
+          at: ~/repo
+
+      - run:
+          name: Publish to NPM
+          command: |
+            sed  -i '/version/s/[^.]*$/'"0-dev${CIRCLE_BUILD_NUM}\",/" package.json
+            npm publish        
+
   deploy:
     <<: *defaults
 
@@ -105,6 +118,9 @@ workflows:
           requires:
             - lint
             - test
+      - deploy_rc:
+          requires:
+            - build
 
   release:
     jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,8 @@ typings/
 # build output
 lib
 
+# yalc
+.yalc
+yalc.lock
+
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "author": "Globality Engineering",
     "license": "MIT",
     "scripts": {
+        "clean": "rm -rf ./lib",
         "build": "babel src --out-dir lib --ignore '**/__tests__/*,**/__mocks__/*'",
         "lint": "eslint src --cache",
         "test": "jest",
-        "verify": "yarn lint && yarn test"
+        "verify": "yarn lint && yarn test",
+        "preyalc": "yarn clean && yarn build"
     },
     "dependencies": {
         "basic-auth": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-express",
-    "version": "0.1.14",
+    "version": "0.2.0",
     "description": "Node Express Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-express",

--- a/src/routes/__tests__/corsAllowedOrigins.test.js
+++ b/src/routes/__tests__/corsAllowedOrigins.test.js
@@ -1,0 +1,44 @@
+import { getContainer, Nodule } from '@globality/nodule-config';
+import 'index';
+import request from 'supertest';
+
+describe.only('API: CORS configuration', () => {
+
+    it('will handle allowed origins configuration', async () => {
+        await Nodule.testing().fromObject({
+            cors: {
+                allowedOrigins: 'https://foo.com,https://bar.com',
+            },
+        }).load();
+
+        const { express } = getContainer('routes');
+        express.get('/api/test', (req, res) => {
+            res.json({ test: true }).end();
+        });
+
+        const res1 = await request(express)
+            .get('/api/test')
+            .set('origin', 'https://foo.com');
+
+        expect(res1.statusCode).toEqual(200);
+        expect(res1.body.test).toEqual(true);
+        expect(res1.header['access-control-allow-origin']).toEqual('https://foo.com');
+        expect(res1.header['access-control-allow-credentials']).toEqual("true");
+
+        const res2 = await request(express)
+            .get('/api/test')
+            .set('origin', 'https://bar.com');
+
+        expect(res2.statusCode).toEqual(200);
+        expect(res2.body.test).toEqual(true);
+        expect(res2.header['access-control-allow-origin']).toEqual('https://bar.com');
+        expect(res2.header['access-control-allow-credentials']).toEqual("true");
+
+        const res3 = await request(express)
+            .get('/api/test')
+            .set('origin', 'http://baz.com');
+
+        expect(res3.statusCode).toEqual(500);
+    });
+
+});

--- a/src/routes/__tests__/corsAllowedOrigins.test.js
+++ b/src/routes/__tests__/corsAllowedOrigins.test.js
@@ -2,7 +2,7 @@ import { getContainer, Nodule } from '@globality/nodule-config';
 import 'index';
 import request from 'supertest';
 
-describe.only('API: CORS configuration', () => {
+describe('API: CORS configuration', () => {
 
     it('will handle allowed origins configuration', async () => {
         await Nodule.testing().fromObject({

--- a/src/routes/__tests__/corsAllowedOrigins.test.js
+++ b/src/routes/__tests__/corsAllowedOrigins.test.js
@@ -23,7 +23,7 @@ describe.only('API: CORS configuration', () => {
         expect(res1.statusCode).toEqual(200);
         expect(res1.body.test).toEqual(true);
         expect(res1.header['access-control-allow-origin']).toEqual('https://foo.com');
-        expect(res1.header['access-control-allow-credentials']).toEqual("true");
+        expect(res1.header['access-control-allow-credentials']).toEqual('true');
 
         const res2 = await request(express)
             .get('/api/test')
@@ -32,7 +32,7 @@ describe.only('API: CORS configuration', () => {
         expect(res2.statusCode).toEqual(200);
         expect(res2.body.test).toEqual(true);
         expect(res2.header['access-control-allow-origin']).toEqual('https://bar.com');
-        expect(res2.header['access-control-allow-credentials']).toEqual("true");
+        expect(res2.header['access-control-allow-credentials']).toEqual('true');
 
         const res3 = await request(express)
             .get('/api/test')

--- a/src/routes/__tests__/corsReflectOrigin.test.js
+++ b/src/routes/__tests__/corsReflectOrigin.test.js
@@ -1,0 +1,30 @@
+import { getContainer, Nodule } from '@globality/nodule-config';
+import 'index';
+import request from 'supertest';
+
+describe.only('API: CORS configuration', () => {
+
+    it('will handle reflect origin configuration', async () => {
+        await Nodule.testing().fromObject({
+            cors: {
+                reflectOrigin: true,
+            },
+        }).load();
+
+        const { express } = getContainer('routes');
+        express.get('/api/test', (req, res) => {
+            res.json({ test: true }).end();
+        });
+
+        const res = await request(express)
+            .get('/api/test')
+            .set('origin', 'http://foobar.com');
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.test).toEqual(true);
+        expect(res.body.test).toEqual(true);
+        expect(res.header['access-control-allow-origin']).toEqual('http://foobar.com');
+        expect(res.header['access-control-allow-credentials']).toEqual("true");
+    });
+
+});

--- a/src/routes/__tests__/corsReflectOrigin.test.js
+++ b/src/routes/__tests__/corsReflectOrigin.test.js
@@ -24,7 +24,7 @@ describe.only('API: CORS configuration', () => {
         expect(res.body.test).toEqual(true);
         expect(res.body.test).toEqual(true);
         expect(res.header['access-control-allow-origin']).toEqual('http://foobar.com');
-        expect(res.header['access-control-allow-credentials']).toEqual("true");
+        expect(res.header['access-control-allow-credentials']).toEqual('true');
     });
 
 });

--- a/src/routes/__tests__/corsReflectOrigin.test.js
+++ b/src/routes/__tests__/corsReflectOrigin.test.js
@@ -2,7 +2,7 @@ import { getContainer, Nodule } from '@globality/nodule-config';
 import 'index';
 import request from 'supertest';
 
-describe.only('API: CORS configuration', () => {
+describe('API: CORS configuration', () => {
 
     it('will handle reflect origin configuration', async () => {
         await Nodule.testing().fromObject({

--- a/src/routes/__tests__/express.test.js
+++ b/src/routes/__tests__/express.test.js
@@ -78,4 +78,5 @@ describe('Basic API', () => {
             },
         });
     });
+
 });

--- a/src/routes/express.js
+++ b/src/routes/express.js
@@ -12,7 +12,7 @@ function getCORSOrigin () {
     if (reflectOrigin) {
         return true;
     }
-
+    
     if (allowedOrigins) {
         return (origin, callback) => {
             if (allowedOrigins.split(',').indexOf(origin) !== -1) {

--- a/src/routes/express.js
+++ b/src/routes/express.js
@@ -3,12 +3,47 @@ import cors from 'cors';
 import helmet from 'helmet';
 import requestId from 'connect-requestid';
 
-import { bind } from '@globality/nodule-config';
+import { bind, getContainer, setDefaults } from '@globality/nodule-config';
 
+function getCORSOrigin () {
+    const { config } = getContainer();
+    const { reflectOrigin, allowedOrigins } = config.cors;
+
+    if (reflectOrigin) {
+        return true;
+    }
+
+    if (allowedOrigins) {
+        return (origin, callback) => {
+            if (allowedOrigins.split(',').indexOf(origin) !== -1) {
+                callback(null, true);
+            } else {
+                callback(new Error('Not allowed by CORS'));
+            }
+        };
+    }
+
+    return null;
+}
+
+setDefaults('cors', {
+    allowedOrigins: '',
+    reflectOrigin: false,
+});
 
 function createExpress() {
+    const corsOptions = {
+        credentials: true,
+        maxAge: 86400,
+    };
+    const corsOrigin = getCORSOrigin();
+
+    if (corsOrigin !== null) {
+        corsOptions.origin = corsOrigin;
+    }
+
     const app = express();
-    app.use(cors({ maxAge: 86400 }));
+    app.use(cors(corsOptions));
     app.use(helmet());
     app.use(requestId);
 

--- a/src/routes/express.js
+++ b/src/routes/express.js
@@ -12,7 +12,7 @@ function getCORSOrigin () {
     if (reflectOrigin) {
         return true;
     }
-    
+
     if (allowedOrigins) {
         return (origin, callback) => {
             if (allowedOrigins.split(',').indexOf(origin) !== -1) {


### PR DESCRIPTION
Updates express routes API to allow cors configuration.

Can configure whether to reflect the request origin or restrict what origins are allowed.

Related to https://globality.atlassian.net/browse/GLOB-45370