### PR TITLE
Feature/glob 50852 cors excluded paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-express",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Node Express Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-express",
@@ -24,7 +24,8 @@
         "helmet": "^3.12.0",
         "http-status-codes": "^1.3.0",
         "jsonwebtoken": "^8.2.0",
-        "lodash": "^4.17.5"
+        "lodash": "^4.17.5",
+        "path-to-regexp": "^6.2.0"
     },
     "peerDependencies": {
         "@globality/nodule-config": ">= 2.13.2 < 3",

--- a/src/index.js
+++ b/src/index.js
@@ -18,3 +18,4 @@ export {
 } from './logging';
 
 export { default as safely } from './decorators';
+export { except } from './utils';

--- a/src/routes/__tests__/corsAllowedOrigins.test.js
+++ b/src/routes/__tests__/corsAllowedOrigins.test.js
@@ -1,8 +1,11 @@
-import { getContainer, Nodule } from '@globality/nodule-config';
+import { clearBinding, getContainer, Nodule } from '@globality/nodule-config';
 import 'index';
 import request from 'supertest';
 
 describe('API: CORS configuration', () => {
+    beforeEach(() => {
+        clearBinding('config');
+    });
 
     it('will handle allowed origins configuration', async () => {
         await Nodule.testing().fromObject({

--- a/src/routes/__tests__/corsReflectOrigin.test.js
+++ b/src/routes/__tests__/corsReflectOrigin.test.js
@@ -1,8 +1,11 @@
-import { getContainer, Nodule } from '@globality/nodule-config';
+import { clearBinding, getContainer, Nodule } from '@globality/nodule-config';
 import 'index';
 import request from 'supertest';
 
 describe('API: CORS configuration', () => {
+    beforeEach(() => {
+        clearBinding('config');
+    });
 
     it('will handle reflect origin configuration', async () => {
         await Nodule.testing().fromObject({
@@ -21,7 +24,6 @@ describe('API: CORS configuration', () => {
             .set('origin', 'http://foobar.com');
 
         expect(res.statusCode).toEqual(200);
-        expect(res.body.test).toEqual(true);
         expect(res.body.test).toEqual(true);
         expect(res.header['access-control-allow-origin']).toEqual('http://foobar.com');
         expect(res.header['access-control-allow-credentials']).toEqual('true');

--- a/src/routes/express.js
+++ b/src/routes/express.js
@@ -5,8 +5,9 @@ import requestId from 'connect-requestid';
 
 import { bind, getContainer, setDefaults } from '@globality/nodule-config';
 
-function getCORSOrigin () {
-    const { config } = getContainer();
+import except from '../utils/except';
+
+function getCORSOrigin (config) {
     const { reflectOrigin, allowedOrigins } = config.cors;
 
     if (reflectOrigin) {
@@ -29,21 +30,25 @@ function getCORSOrigin () {
 setDefaults('cors', {
     allowedOrigins: '',
     reflectOrigin: false,
+    excludedPaths: null,
 });
 
 function createExpress() {
+    const { config } = getContainer();
+
     const corsOptions = {
         credentials: true,
         maxAge: 86400,
     };
-    const corsOrigin = getCORSOrigin();
+
+    const corsOrigin = getCORSOrigin(config);
 
     if (corsOrigin !== null) {
         corsOptions.origin = corsOrigin;
     }
 
     const app = express();
-    app.use(cors(corsOptions));
+    app.use(except(config.cors.excludedPaths || null, cors(corsOptions)));
     app.use(helmet());
     app.use(requestId);
 

--- a/src/utils/except.js
+++ b/src/utils/except.js
@@ -1,0 +1,18 @@
+import { pathToRegexp } from 'path-to-regexp';
+
+/**
+ * Will only execute provided middleware if current request path is not included in a
+ * given list of express paths.
+ * @param {string|string[]} paths string or list of strings that defines express paths where
+ * given middleware won't be executed. It is also possible to provide regular expressions.
+ * @param {middlewareFn} middlewareFn Middleware function to be executed if current path does not
+ * match `paths` param.
+ * @returns Middleware function
+ */
+export default function except(paths, middlewareFn) {
+    const regexp = paths ? pathToRegexp(paths) : null;
+    return (req, res, next) => {
+        if (regexp && regexp.test(req.path)) return next();
+        return middlewareFn(req, res, next);
+    };
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as except } from './except';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4406,6 +4406,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
+  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
+
 path-type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"


### PR DESCRIPTION
A new configuration option has been added to CORS called `excludedPaths` that allow disabling CORS restrictions for a given path or list of paths.

This will be used on **styx** to disable CORS for `/api/health/` endpoint

Related: [GLOB-50852]

[GLOB-50852]: https://globality.atlassian.net/browse/GLOB-50852