### PR TITLE
GLOB-55758 Adding 'X-Request-Id' as exposed headers by CORS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ lib
 yalc.lock
 
 .DS_Store
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-express",
-    "version": "0.3.0",
+    "version": "0.5.0",
     "description": "Node Express Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-express",

--- a/src/routes/__tests__/corsExposedHeaders.test.js
+++ b/src/routes/__tests__/corsExposedHeaders.test.js
@@ -1,0 +1,30 @@
+import { clearBinding, getContainer, Nodule } from '@globality/nodule-config';
+import 'index';
+import request from 'supertest';
+
+describe('API: CORS configuration', () => {
+    beforeEach(() => {
+        clearBinding('config');
+    });
+
+    it('will add "access-control-expose-headers" in the response headers', async () => {
+        await Nodule.testing().fromObject({
+            cors: {
+                reflectOrigin: true,
+            },
+        }).load();
+
+        const { express } = getContainer('routes');
+        express.get('/api/test', (req, res) => {
+            res.json({ test: true }).end();
+        });
+
+        const res = await request(express)
+            .get('/api/test')
+            .set('origin', 'http://foobar.com');
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.test).toEqual(true);
+        expect(res.header['access-control-expose-headers']).toEqual('X-Request-Id');
+    });
+});

--- a/src/routes/express.js
+++ b/src/routes/express.js
@@ -40,6 +40,7 @@ function createExpress() {
 
     if (corsOrigin !== null) {
         corsOptions.origin = corsOrigin;
+        corsOptions.exposedHeaders = ['X-Request-Id'];
     }
 
     const app = express();


### PR DESCRIPTION
## Details

This improvement/feature was made due a requirement to complete this ticket:
- [GLOB-55758](https://globality.atlassian.net/browse/GLOB-55758)

There's a way to read the `X-Request-Id` by taking it from response headers. However due to our CORS configuration it can not be possible if we do not add this header: `'Access-Control-Expose-Headers': 'X-Request-Id'`.

## Checks:

- [ ] Manual tested
- [x] Unit Tested