### PR TITLE
Remove "merge" from dependency tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-express",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "Node Express Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-express",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
         "js-yaml": "^3.13.1",
         "just-extend": "^4.0.2",
         "extend": "^2.0.2",
-        "merge": "^1.2.1",
         "randomatic": "^3.1.1",
         "cryptiles": "^4.1.3",
         "handlebars": "^4.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4262,11 +4262,6 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
-
 methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"


### PR DESCRIPTION
* Delete line from package.json
* Delete entry from yarn.lock
* This resolution was added ~2 years ago and is no longer needed
* While unused its existence still triggers a security notification