### PR TITLE
GLOB-70859 Bump version to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-express",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "Node Express Conventions",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-express",


### PR DESCRIPTION
Forgot to do this in #66 
Looks like we also have tags in git for each version; I assume I manually push up the `0.6.1` tag after this is merged?